### PR TITLE
added cstring include to parOptProblem

### DIFF
--- a/src/ParOptProblem.cpp
+++ b/src/ParOptProblem.cpp
@@ -1,6 +1,6 @@
 #include "ParOptProblem.h"
 #include "ParOptComplexStep.h"
-
+#include <cstring>
 void ParOptProblem::checkGradients( double dh, ParOptVec *xvec,
                                     int check_hvec_product ){
   ParOptVec *x = xvec;


### PR DESCRIPTION
Compiling paropt failed for me, with the error message
```
ParOptProblem.cpp: In member function 'void ParOptProblem::checkGradients(double, ParOptVec*, int)':
ParOptProblem.cpp:291:5: error: 'memset' was not declared in this scope
     memset(Cw, 0, nwcon*(nwblock+1)/2*sizeof(ParOptScalar));
     ^~~~~~
ParOptProblem.cpp:291:5: note: suggested alternative: 'wmemset'
     memset(Cw, 0, nwcon*(nwblock+1)/2*sizeof(ParOptScalar));
     ^~~~~~
     wmemset
../ParOpt_Common.mk:20: recipe for target 'ParOptProblem.o' failed
```

I'm not sure if this is somehow specific to my setup, but adding the include statement solved the issue for me.