### PR TITLE
Adding missing cstring includes for code to compile

### DIFF
--- a/src/ParOptCompactEigenvalueApprox.cpp
+++ b/src/ParOptCompactEigenvalueApprox.cpp
@@ -1,3 +1,4 @@
+#include <cstring>
 #include "ParOptCompactEigenvalueApprox.h"
 #include "ParOptComplexStep.h"
 

--- a/src/ParOptTrustRegion.cpp
+++ b/src/ParOptTrustRegion.cpp
@@ -1,3 +1,4 @@
+#include <cstring>
 #include "ParOptTrustRegion.h"
 #include "ParOptComplexStep.h"
 


### PR DESCRIPTION
Due to recent commits compiling fails on some systems (see below)

At minimum, including the `cstring` lib in the implementation addresses this.
Alternatively, (and depending on include preference strategy) this could be included in headers. 

```
mpicxx -fPIC -O3 -I/home/mdolabuser/packages/paropt/src -c ParOptTrustRegion.cpp -o ParOptTrustRegion.o
ParOptTrustRegion.cpp: In member function 'void ParOptTrustRegion::update(ParOptVec*, const ParOptScalar*, ParOptVec*, double*, double*, double*)':
ParOptTrustRegion.cpp:837:19: error: 'strlen' was not declared in this scope
     sprintf(&info[strlen(info)], "%s ", "dampH");
                   ^~~~~~
ParOptTrustRegion.cpp:837:19: note: suggested alternative: 'mbrlen'
     sprintf(&info[strlen(info)], "%s ", "dampH");
                   ^~~~~~
                   mbrlen
ParOptTrustRegion.cpp:841:19: error: 'strlen' was not declared in this scope
     sprintf(&info[strlen(info)], "%s ", "skipH");
                   ^~~~~~
ParOptTrustRegion.cpp:841:19: note: suggested alternative: 'mbrlen'
     sprintf(&info[strlen(info)], "%s ", "skipH");
                   ^~~~~~
                   mbrlen
ParOptTrustRegion.cpp:845:19: error: 'strlen' was not declared in this scope
     sprintf(&info[strlen(info)], "%d/%d", subproblem_iters,
                   ^~~~~~
ParOptTrustRegion.cpp:845:19: note: suggested alternative: 'mbrlen'
     sprintf(&info[strlen(info)], "%d/%d", subproblem_iters,
                   ^~~~~~
                   mbrlen
ParOptTrustRegion.cpp:849:19: error: 'strlen' was not declared in this scope
     sprintf(&info[strlen(info)], "%d", subproblem_iters);
                   ^~~~~~
ParOptTrustRegion.cpp:849:19: note: suggested alternative: 'mbrlen'
     sprintf(&info[strlen(info)], "%d", subproblem_iters);
                   ^~~~~~
                   mbrlen
../ParOpt_Common.mk:20: recipe for target 'ParOptTrustRegion.o' failed
make[1]: *** [ParOptTrustRegion.o] Error 1
make[1]: Leaving directory '/home/mdolabuser/packages/paropt/src'
Makefile:14: recipe for target 'default' failed
```

and 

```
mpicxx -fPIC -O3 -I/home/mdolabuser/packages/paropt/src -c ParOptCompactEigenvalueApprox.cpp -o ParOptCompactEigenvalueApprox.o
ParOptCompactEigenvalueApprox.cpp: In constructor 'ParOptCompactEigenApprox::ParOptCompactEigenApprox(ParOptProblem*, int)':
ParOptCompactEigenvalueApprox.cpp:32:3: error: 'memset' was not declared in this scope
   memset(M, 0, N*N*sizeof(ParOptScalar));
   ^~~~~~
ParOptCompactEigenvalueApprox.cpp:32:3: note: suggested alternative: 'wmemset'
   memset(M, 0, N*N*sizeof(ParOptScalar));
   ^~~~~~
   wmemset
ParOptCompactEigenvalueApprox.cpp: In member function 'virtual int ParOptEigenQuasiNewton::getCompactMat(ParOptScalar*, const ParOptScalar**, const ParOptScalar**, ParOptVec***)':
ParOptCompactEigenvalueApprox.cpp:208:3: error: 'memset' was not declared in this scope
   memset(M, 0, max_vecs*max_vecs*sizeof(ParOptScalar));
   ^~~~~~
ParOptCompactEigenvalueApprox.cpp:208:3: note: suggested alternative: 'wmemset'
   memset(M, 0, max_vecs*max_vecs*sizeof(ParOptScalar));
   ^~~~~~
   wmemset
../ParOpt_Common.mk:20: recipe for target 'ParOptCompactEigenvalueApprox.o' failed
make[1]: *** [ParOptCompactEigenvalueApprox.o] Error 1
make[1]: Leaving directory '/home/mdolabuser/packages/paropt/src'
Makefile:14: recipe for target 'default' failed
```